### PR TITLE
Add boostrolemanager cog to bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDEs
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cogs/boostrolemanager.py
+++ b/cogs/boostrolemanager.py
@@ -23,3 +23,6 @@ class BoostTracker(commands.Cog):
             role = discord.utils.get(after.guild.roles, name=role_name)
             if role not in after.roles: continue
             await after.remove_roles(role)
+
+async def setup(bot):
+    await bot.add_cog(BoostTracker(bot), guilds=[discord.Object(id=bot.guild_id)])

--- a/cogs/boostrolemanager.py
+++ b/cogs/boostrolemanager.py
@@ -1,0 +1,25 @@
+import discord
+from discord.ext import commands
+
+class BoostTracker(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+    
+    @commands.Cog.listener()
+    async def on_member_update(self, before, after):
+        if before.premium_since == after.premium_since or after.premium_since:
+            return
+
+        roles_to_remove = [
+            "nitro-a",
+            "nitro-b",
+            "nitro-c",
+            "nitro-d",
+            "nitro-e",
+            "nitro-f"
+        ]
+
+        for role_name in roles_to_remove:
+            role = discord.utils.get(after.guild.roles, name=role_name)
+            if role not in after.roles: continue
+            await after.remove_roles(role)

--- a/cogs/boostrolemanager.py
+++ b/cogs/boostrolemanager.py
@@ -7,7 +7,7 @@ class BoostTracker(commands.Cog):
     
     @commands.Cog.listener()
     async def on_member_update(self, before, after):
-        if before.premium_since == after.premium_since or after.premium_since:
+        if (before.premium_since is None) == (after.premium_since is None) or after.premium_since:
             return
 
         roles_to_remove = [

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ class APBot(commands.Bot):
                               'cogs.rolereact',
                               'cogs.study',
                               'cogs.exams_automation.day_zero_complete',
+                              'cogs.boostrolemanager',
                               # 'cogs.threads',
                               ]
         for extension in initial_extensions:


### PR DESCRIPTION
As title describes. The idea is that whenever someone unboosts (i.e. `premium_since` property of the `Member` goes from non-`None` to `None`), any nitro color role they have should be purged.