### PR TITLE
DM users when they receive helper role

### DIFF
--- a/src/cogs/helper_dm.py
+++ b/src/cogs/helper_dm.py
@@ -1,0 +1,50 @@
+import nextcord
+from nextcord.ext import commands
+from bot_base import APBot
+
+HELPER_ROLE_NAMES = {"Helper (Click on their names!)"}
+
+HELPER_DM_MESSAGE = """Hi there!
+
+Thanks for signing up to be a Helper <:pikaheart:357317554600935424>. To make your experience as smooth as possible, we’re here to help and make sure that you get treated fairly. Below are all instances that you can report to <@1464966749643341847>, and we’ll take care of it from our end.
+
+- Unsolicited pinging
+- Unsolicited DM’ing
+- Rude behavior
+- Disruptive behavior that interferes with helping
+- Getting pinged by /question when the user hasn’t waited 10 minutes
+
+When reporting, please make sure to include the user’s discord handle and a screenshot if possible.
+
+Thank you! As always, feel free to send suggestions & feedback about the Helper system to <@1464966749643341847>."""
+
+
+class HelperDMCog(commands.Cog):
+    def __init__(self, bot: APBot):
+        self.bot = bot
+
+    def gained_helper_role(self, before, after) -> bool:
+        before_role_ids = {role.id for role in before.roles}
+
+        for role in after.roles:
+            if role.id not in before_role_ids and role.name in HELPER_ROLE_NAMES:
+                return True
+
+        return False
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before, after):
+        if getattr(after, "bot", False):
+            return
+
+        if not self.gained_helper_role(before, after):
+            return
+
+        try:
+            await after.send(HELPER_DM_MESSAGE)
+        except (nextcord.Forbidden, nextcord.HTTPException):
+            pass
+
+
+def setup(bot: APBot):
+    bot.add_cog(HelperDMCog(bot))

--- a/src/startup.py
+++ b/src/startup.py
@@ -9,6 +9,7 @@ DEFAULT_COGS = [
     "cogs.recurrent",
     "cogs.tags",
     "cogs.study",
+    "cogs.helper_dm",
     "cogs.events",
     "cogs.modmail",
     "cogs.special",

--- a/tests/test_helper_dm.py
+++ b/tests/test_helper_dm.py
@@ -1,0 +1,53 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from cogs.helper_dm import HelperDMCog, HELPER_DM_MESSAGE
+
+
+def role(role_id, name):
+    return SimpleNamespace(id=role_id, name=name)
+
+
+def member(roles, bot=False):
+    return SimpleNamespace(roles=roles, bot=bot, send=AsyncMock())
+
+
+def test_gained_helper_role_detects_new_helper_role():
+    cog = HelperDMCog(bot=object())
+
+    before = member([role(1, "Student")])
+    after = member([role(1, "Student"), role(2, "Helper (Click on their names!)")])
+
+    assert cog.gained_helper_role(before, after) is True
+
+
+def test_gained_helper_role_ignores_existing_helper_role():
+    cog = HelperDMCog(bot=object())
+
+    before = member([role(2, "Helper (Click on their names!)")])
+    after = member([role(2, "Helper (Click on their names!)")])
+
+    assert cog.gained_helper_role(before, after) is False
+
+
+def test_on_member_update_dms_new_helper():
+    cog = HelperDMCog(bot=object())
+
+    before = member([role(1, "Student")])
+    after = member([role(1, "Student"), role(2, "Helper (Click on their names!)")])
+
+    asyncio.run(cog.on_member_update(before, after))
+
+    after.send.assert_awaited_once_with(HELPER_DM_MESSAGE)
+
+
+def test_on_member_update_does_not_dm_bots():
+    cog = HelperDMCog(bot=object())
+
+    before = member([role(1, "Student")])
+    after = member([role(1, "Student"), role(2, "Helper (Click on their names!)")], bot=True)
+
+    asyncio.run(cog.on_member_update(before, after))
+
+    after.send.assert_not_awaited()


### PR DESCRIPTION
Added Task 1.

Changes:
- Sends the DM when a user receives the Helper (Click on their names!) role
- Handles closed DMs without crashing
