### PR TITLE
Fix mod role check with missing config role IDs

### DIFF
--- a/src/cogs/moderation/infraction.py
+++ b/src/cogs/moderation/infraction.py
@@ -30,8 +30,12 @@ class Infraction(commands.Cog):
     def has_mod_role(self, member: Member) -> bool:
         allowed_role_names = {"Trial Chat Moderator", "Chat Moderator", "Admin"}
         allowed_role_ids = {
-            conf.get("bot_staff_role_id"),
-            conf.get("special_perms_role_id"),
+            role_id
+            for role_id in (
+                conf.get("bot_staff_role_id"),
+                conf.get("special_perms_role_id"),
+            )
+            if role_id is not None
         }
 
         perms = getattr(member, "guild_permissions", None)


### PR DESCRIPTION
Fixes CI failure from has_mod_role.

The config role IDs can be None in tests, which made fake roles without an id match because None was in allowed_role_ids. This filters out None before checking role IDs.