### PR TITLE
Wordle leaderboard

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore:'audioop' is deprecated and slated for removal in Python 3.13:DeprecationWarning:nextcord.player
+    ignore:pkg_resources is deprecated as an API:UserWarning:nextcord.health_check

--- a/src/cogs/moderation/infraction.py
+++ b/src/cogs/moderation/infraction.py
@@ -30,8 +30,12 @@ class Infraction(commands.Cog):
     def has_mod_role(self, member: Member) -> bool:
         allowed_role_names = {"Trial Chat Moderator", "Chat Moderator", "Admin"}
         allowed_role_ids = {
-            conf.get("bot_staff_role_id"),
-            conf.get("special_perms_role_id"),
+            role_id
+            for role_id in (
+                conf.get("bot_staff_role_id"),
+                conf.get("special_perms_role_id"),
+            )
+            if role_id is not None
         }
 
         perms = getattr(member, "guild_permissions", None)

--- a/src/cogs/wordle.py
+++ b/src/cogs/wordle.py
@@ -1,0 +1,200 @@
+import re
+from datetime import datetime, timezone
+
+import nextcord
+from nextcord import Embed, Interaction, SlashOption, slash_command
+from nextcord.ext import commands
+
+from app_config import get_command_guild_ids, load_optional_config
+from bot_base import APBot
+
+conf = load_optional_config()
+COMMAND_GUILD_IDS = get_command_guild_ids(conf)
+
+WORDLE_RESULT_RE = re.compile(r"Wordle\s+(\d[\d,]*)\s+([1-6X])/6(\*)?", re.IGNORECASE)
+
+
+def parse_date(value: str):
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def parse_wordle_result(content: str):
+    match = WORDLE_RESULT_RE.search(content)
+    if not match:
+        return None
+
+    puzzle = int(match.group(1).replace(",", ""))
+    tries_text = match.group(2)
+    hard_mode = bool(match.group(3))
+
+    failed = tries_text.upper() == "X"
+    tries = None if failed else int(tries_text)
+    score = 7 if failed else tries - 1 if hard_mode else tries
+
+    return {
+        "puzzle": puzzle,
+        "tries": tries,
+        "failed": failed,
+        "hard_mode": hard_mode,
+        "score": score,
+    }
+
+
+def is_wordle_summary_message(content: str) -> bool:
+    text = content.lower()
+    return "yesterday" in text and "result" in text
+
+
+def format_wordle_leaderboard(rows):
+    if not rows:
+        return "No Wordle scores have been recorded yet."
+
+    lines = []
+    for index, row in enumerate(rows, start=1):
+        user_id = row["user_id"]
+        total = row["total_score"]
+        games = row["games"]
+        hard_games = row["hard_games"]
+        failures = row["failures"]
+        lines.append(
+            f"{index}. <@{user_id}> — {total} pts over {games} game(s), {hard_games} hard, {failures} failed"
+        )
+
+    return "\n".join(lines)
+
+
+class Wordle(commands.Cog):
+    def __init__(self, bot: APBot) -> None:
+        self.bot = bot
+
+    @slash_command(name="wordle", description="Manage the Wordle leaderboard", guild_ids=COMMAND_GUILD_IDS)
+    async def wordle(self, inter: Interaction):
+        pass
+
+    @wordle.subcommand(name="start", description="Start a seasonal Wordle leaderboard")
+    async def wordle_start(
+        self,
+        inter: Interaction,
+        start_date: str = SlashOption(name="start_date", description="YYYY-MM-DD", required=True),
+        end_date: str = SlashOption(name="end_date", description="YYYY-MM-DD", required=True),
+    ) -> None:
+        await inter.response.defer(ephemeral=True)
+
+        start = parse_date(start_date)
+        end = parse_date(end_date)
+
+        if start is None or end is None:
+            await inter.followup.send("Use dates in YYYY-MM-DD format.", ephemeral=True)
+            return
+
+        if end < start:
+            await inter.followup.send("End date must be after start date.", ephemeral=True)
+            return
+
+        await self.bot.db.wordle.start_season(inter.guild.id, inter.channel.id, start.isoformat(), end.isoformat())
+
+        processed = 0
+        async for message in inter.channel.history(limit=50):
+            if await self.process_wordle_result_message(message):
+                processed += 1
+
+        await inter.followup.send(
+            f"Started Wordle season from `{start.isoformat()}` to `{end.isoformat()}`. Processed {processed} existing result(s).",
+            ephemeral=True,
+        )
+
+    @wordle.subcommand(name="leaderboard", description="Show the active Wordle leaderboard")
+    async def wordle_leaderboard(self, inter: Interaction) -> None:
+        season = await self.bot.db.wordle.get_active_season(inter.guild.id)
+
+        if not season:
+            await inter.send("No active Wordle season.", ephemeral=True)
+            return
+
+        rows = await self.bot.db.wordle.get_leaderboard(
+            inter.guild.id,
+            season["start_date"],
+            season["end_date"],
+        )
+
+        embed = Embed(
+            title="Wordle Leaderboard",
+            description=format_wordle_leaderboard(rows),
+            color=self.bot.colors.get("green", nextcord.Color.green()),
+        )
+
+        await inter.send(embed=embed)
+
+    async def process_wordle_result_message(self, message: nextcord.Message) -> bool:
+        if message.guild is None or message.author.bot:
+            return False
+
+        if getattr(message.channel, "name", None) != "wordle":
+            return False
+
+        result = parse_wordle_result(message.content)
+        if result is None:
+            return False
+
+        season = await self.bot.db.wordle.get_active_season(message.guild.id)
+        if not season:
+            return False
+
+        played_date = message.created_at.astimezone(timezone.utc).date().isoformat()
+        if played_date < season["start_date"] or played_date > season["end_date"]:
+            return False
+
+        await self.bot.db.wordle.save_result(
+            guild_id=message.guild.id,
+            channel_id=message.channel.id,
+            user_id=message.author.id,
+            username=message.author.display_name,
+            puzzle=result["puzzle"],
+            tries=result["tries"],
+            failed=result["failed"],
+            hard_mode=result["hard_mode"],
+            score=result["score"],
+            played_date=played_date,
+            message_id=message.id,
+            season_start=season["start_date"],
+            season_end=season["end_date"],
+        )
+        return True
+
+    async def post_leaderboard(self, message: nextcord.Message) -> None:
+        season = await self.bot.db.wordle.get_active_season(message.guild.id)
+        if not season:
+            return
+
+        if season.get("last_summary_message_id") == message.id:
+            return
+
+        rows = await self.bot.db.wordle.get_leaderboard(
+            message.guild.id,
+            season["start_date"],
+            season["end_date"],
+        )
+
+        embed = Embed(
+            title="Updated Wordle Leaderboard",
+            description=format_wordle_leaderboard(rows),
+            color=self.bot.colors.get("green", nextcord.Color.green()),
+        )
+
+        await message.channel.send(embed=embed)
+        await self.bot.db.wordle.set_last_summary_message(message.guild.id, message.id)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: nextcord.Message) -> None:
+        await self.process_wordle_result_message(message)
+
+        if message.guild and message.author.bot and getattr(message.channel, "name", None) == "wordle":
+            if is_wordle_summary_message(message.content):
+                await self.post_leaderboard(message)
+
+
+def setup(bot: APBot):
+    bot.add_cog(Wordle(bot))

--- a/src/cogs/wordle.py
+++ b/src/cogs/wordle.py
@@ -13,7 +13,7 @@ conf = load_optional_config()
 COMMAND_GUILD_IDS = get_command_guild_ids(conf)
 
 WORDLE_RESULT_RE = re.compile(r"\bWordle\s+(\d[\d,]*)\s+([1-6X])/6(\*)?", re.IGNORECASE)
-WORDLE_SUMMARY_RE = re.compile(r"([1-6X])/6(\*)?\s*[:\-]\s*((?:<@!?\d+>\s*)+)", re.IGNORECASE)
+WORDLE_SUMMARY_RE = re.compile(r"\b([1-6X])/6(\*)?(?=\s|[:\-–—]|$)\s*(?::|[-–—])?\s*((?:<@!?\d+>[\s,;]*)+)", re.IGNORECASE)
 MENTION_RE = re.compile(r"<@!?(\d+)>")
 
 
@@ -31,7 +31,7 @@ def can_manage_wordle(member) -> bool:
         return True
 
     perms = getattr(member, "guild_permissions", None)
-    if perms and (perms.manage_guild or perms.administrator):
+    if perms and (getattr(perms, "manage_guild", False) or getattr(perms, "administrator", False)):
         return True
 
     allowed_role_names = {"Trial Chat Moderator", "Chat Moderator", "Admin"}
@@ -44,7 +44,11 @@ def can_manage_wordle(member) -> bool:
         if role_id is not None
     }
 
-    return any(role.name in allowed_role_names or role.id in allowed_role_ids for role in getattr(member, "roles", []))
+    return any(
+        getattr(role, "name", None) in allowed_role_names
+        or getattr(role, "id", None) in allowed_role_ids
+        for role in getattr(member, "roles", [])
+    )
 
 
 def is_wordle_channel(channel) -> bool:
@@ -56,6 +60,24 @@ def get_history_bounds(start, end):
     end_plus_two = end + timedelta(days=2)
     before = datetime(end_plus_two.year, end_plus_two.month, end_plus_two.day, tzinfo=timezone.utc)
     return after, before
+
+
+def get_message_date(message: nextcord.Message):
+    created_at = message.created_at
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    return created_at.astimezone(timezone.utc).date()
+
+
+def get_summary_played_date(content: str, message: nextcord.Message):
+    created_date = get_message_date(message)
+    if "yesterday" in content.lower():
+        return created_date - timedelta(days=1)
+    return created_date
+
+
+def date_in_season(played_date: str, season: dict) -> bool:
+    return season["start_date"] <= played_date <= season["end_date"]
 
 
 def wordle_score(tries, failed: bool, hard_mode: bool) -> int:
@@ -153,6 +175,18 @@ def format_wordle_leaderboard(rows):
 class Wordle(commands.Cog):
     def __init__(self, bot: APBot) -> None:
         self.bot = bot
+
+    async def resolve_username(self, guild: nextcord.Guild, user_id: int) -> str:
+        member = guild.get_member(user_id)
+        if member:
+            return member.display_name
+
+        try:
+            member = await guild.fetch_member(user_id)
+        except (nextcord.NotFound, nextcord.Forbidden, nextcord.HTTPException):
+            return str(user_id)
+
+        return member.display_name
 
     @slash_command(name="wordle", description="Manage the Wordle leaderboard", guild_ids=COMMAND_GUILD_IDS)
     async def wordle(self, inter: Interaction):
@@ -266,8 +300,8 @@ class Wordle(commands.Cog):
         if not season:
             return False
 
-        played_date = message.created_at.astimezone(timezone.utc).date().isoformat()
-        if played_date < season["start_date"] or played_date > season["end_date"]:
+        played_date = get_message_date(message).isoformat()
+        if not date_in_season(played_date, season):
             return False
 
         await self.bot.db.wordle.save_result(
@@ -305,17 +339,14 @@ class Wordle(commands.Cog):
         if not season:
             return 0
 
-        created_date = message.created_at.astimezone(timezone.utc).date()
-        played_date = created_date - timedelta(days=1) if "yesterday" in text.lower() else created_date
-        played_date_text = played_date.isoformat()
+        played_date_text = get_summary_played_date(text, message).isoformat()
 
-        if played_date_text < season["start_date"] or played_date_text > season["end_date"]:
+        if not date_in_season(played_date_text, season):
             return 0
 
         count = 0
         for entry in entries:
-            member = message.guild.get_member(entry["user_id"])
-            username = member.display_name if member else str(entry["user_id"])
+            username = await self.resolve_username(message.guild, entry["user_id"])
 
             await self.bot.db.wordle.save_result(
                 guild_id=message.guild.id,
@@ -345,10 +376,20 @@ class Wordle(commands.Cog):
         if season.get("last_summary_message_id") == message.id:
             return
 
-        await self.process_wordle_summary_message(message)
+        text = get_message_text(message)
+        played_date = get_summary_played_date(text, message).isoformat()
+        if not date_in_season(played_date, season):
+            return
 
+        processed = await self.process_wordle_summary_message(message)
         async for recent_message in message.channel.history(limit=100):
-            await self.process_wordle_result_message(recent_message)
+            if get_message_date(recent_message).isoformat() != played_date:
+                continue
+            if await self.process_wordle_result_message(recent_message):
+                processed += 1
+
+        if processed == 0:
+            return
 
         rows = await self.bot.db.wordle.get_leaderboard(
             message.guild.id,

--- a/src/cogs/wordle.py
+++ b/src/cogs/wordle.py
@@ -24,6 +24,40 @@ def parse_date(value: str):
         return None
 
 
+
+def can_manage_wordle(member) -> bool:
+    owner_ids = conf.get("owner_ids") or []
+    if getattr(member, "id", None) in owner_ids:
+        return True
+
+    perms = getattr(member, "guild_permissions", None)
+    if perms and (perms.manage_guild or perms.administrator):
+        return True
+
+    allowed_role_names = {"Trial Chat Moderator", "Chat Moderator", "Admin"}
+    allowed_role_ids = {
+        role_id
+        for role_id in (
+            conf.get("bot_staff_role_id"),
+            conf.get("special_perms_role_id"),
+        )
+        if role_id is not None
+    }
+
+    return any(role.name in allowed_role_names or role.id in allowed_role_ids for role in getattr(member, "roles", []))
+
+
+def is_wordle_channel(channel) -> bool:
+    return (getattr(channel, "name", "") or "").lower() == "wordle"
+
+
+def get_history_bounds(start, end):
+    after = datetime(start.year, start.month, start.day, tzinfo=timezone.utc) - timedelta(seconds=1)
+    end_plus_two = end + timedelta(days=2)
+    before = datetime(end_plus_two.year, end_plus_two.month, end_plus_two.day, tzinfo=timezone.utc)
+    return after, before
+
+
 def wordle_score(tries, failed: bool, hard_mode: bool) -> int:
     if failed:
         return 7
@@ -133,6 +167,14 @@ class Wordle(commands.Cog):
     ) -> None:
         await inter.response.defer(ephemeral=True)
 
+        if not can_manage_wordle(inter.user):
+            await inter.followup.send("Only staff can start Wordle seasons.", ephemeral=True)
+            return
+
+        if not is_wordle_channel(inter.channel):
+            await inter.followup.send("Run this in #wordle.", ephemeral=True)
+            return
+
         start = parse_date(start_date)
         end = parse_date(end_date)
 
@@ -146,16 +188,46 @@ class Wordle(commands.Cog):
 
         await self.bot.db.wordle.start_season(inter.guild.id, inter.channel.id, start.isoformat(), end.isoformat())
 
-        processed = 0
-        async for message in inter.channel.history(limit=50):
-            if await self.process_wordle_result_message(message):
-                processed += 1
-            processed += await self.process_wordle_summary_message(message)
+        processed = await self.sync_channel_history(inter.channel, start, end)
 
         await inter.followup.send(
             f"Started Wordle season from `{start.isoformat()}` to `{end.isoformat()}`. Processed {processed} existing result(s).",
             ephemeral=True,
         )
+
+    async def sync_channel_history(self, channel, start, end) -> int:
+        after, before = get_history_bounds(start, end)
+        processed = 0
+
+        async for message in channel.history(limit=None, after=after, before=before, oldest_first=True):
+            if await self.process_wordle_result_message(message):
+                processed += 1
+            processed += await self.process_wordle_summary_message(message)
+
+        return processed
+
+    @wordle.subcommand(name="sync", description="Sync past Wordle messages for the active season")
+    async def wordle_sync(self, inter: Interaction) -> None:
+        await inter.response.defer(ephemeral=True)
+
+        if not can_manage_wordle(inter.user):
+            await inter.followup.send("Only staff can sync Wordle seasons.", ephemeral=True)
+            return
+
+        if not is_wordle_channel(inter.channel):
+            await inter.followup.send("Run this in #wordle.", ephemeral=True)
+            return
+
+        season = await self.bot.db.wordle.get_active_season(inter.guild.id)
+        if not season:
+            await inter.followup.send("No active Wordle season.", ephemeral=True)
+            return
+
+        start = parse_date(season["start_date"])
+        end = parse_date(season["end_date"])
+        processed = await self.sync_channel_history(inter.channel, start, end)
+
+        await inter.followup.send(f"Synced {processed} Wordle result(s).", ephemeral=True)
 
     @wordle.subcommand(name="leaderboard", description="Show the active Wordle leaderboard")
     async def wordle_leaderboard(self, inter: Interaction) -> None:
@@ -183,7 +255,7 @@ class Wordle(commands.Cog):
         if message.guild is None or message.author.bot:
             return False
 
-        if getattr(message.channel, "name", None) != "wordle":
+        if not is_wordle_channel(message.channel):
             return False
 
         result = parse_wordle_result(message.content)
@@ -220,7 +292,7 @@ class Wordle(commands.Cog):
         if message.guild is None or not message.author.bot:
             return 0
 
-        if getattr(message.channel, "name", None) != "wordle":
+        if not is_wordle_channel(message.channel):
             return 0
 
         text = get_message_text(message)
@@ -297,7 +369,7 @@ class Wordle(commands.Cog):
     async def on_message(self, message: nextcord.Message) -> None:
         await self.process_wordle_result_message(message)
 
-        if message.guild and message.author.bot and getattr(message.channel, "name", None) == "wordle":
+        if message.guild and message.author.bot and is_wordle_channel(message.channel):
             if is_wordle_summary_message(get_message_text(message)):
                 await asyncio.sleep(5)
                 await self.post_leaderboard(message)

--- a/src/cogs/wordle.py
+++ b/src/cogs/wordle.py
@@ -1,5 +1,6 @@
+import asyncio
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import nextcord
 from nextcord import Embed, Interaction, SlashOption, slash_command
@@ -11,7 +12,9 @@ from bot_base import APBot
 conf = load_optional_config()
 COMMAND_GUILD_IDS = get_command_guild_ids(conf)
 
-WORDLE_RESULT_RE = re.compile(r"Wordle\s+(\d[\d,]*)\s+([1-6X])/6(\*)?", re.IGNORECASE)
+WORDLE_RESULT_RE = re.compile(r"\bWordle\s+(\d[\d,]*)\s+([1-6X])/6(\*)?", re.IGNORECASE)
+WORDLE_SUMMARY_RE = re.compile(r"([1-6X])/6(\*)?\s*[:\-]\s*((?:<@!?\d+>\s*)+)", re.IGNORECASE)
+MENTION_RE = re.compile(r"<@!?(\d+)>")
 
 
 def parse_date(value: str):
@@ -19,6 +22,14 @@ def parse_date(value: str):
         return datetime.strptime(value, "%Y-%m-%d").date()
     except ValueError:
         return None
+
+
+def wordle_score(tries, failed: bool, hard_mode: bool) -> int:
+    if failed:
+        return 7
+    if hard_mode:
+        return tries - 1
+    return tries
 
 
 def parse_wordle_result(content: str):
@@ -29,23 +40,67 @@ def parse_wordle_result(content: str):
     puzzle = int(match.group(1).replace(",", ""))
     tries_text = match.group(2)
     hard_mode = bool(match.group(3))
-
     failed = tries_text.upper() == "X"
     tries = None if failed else int(tries_text)
-    score = 7 if failed else tries - 1 if hard_mode else tries
 
     return {
         "puzzle": puzzle,
         "tries": tries,
         "failed": failed,
         "hard_mode": hard_mode,
-        "score": score,
+        "score": wordle_score(tries, failed, hard_mode),
     }
+
+
+def parse_wordle_summary_text(content: str):
+    entries = []
+
+    for match in WORDLE_SUMMARY_RE.finditer(content):
+        tries_text = match.group(1)
+        hard_mode = bool(match.group(2))
+        mention_text = match.group(3)
+        failed = tries_text.upper() == "X"
+        tries = None if failed else int(tries_text)
+
+        for user_id in MENTION_RE.findall(mention_text):
+            entries.append({
+                "user_id": int(user_id),
+                "tries": tries,
+                "failed": failed,
+                "hard_mode": hard_mode,
+                "score": wordle_score(tries, failed, hard_mode),
+            })
+
+    return entries
 
 
 def is_wordle_summary_message(content: str) -> bool:
     text = content.lower()
-    return "yesterday" in text and "result" in text
+    return (
+        ("yesterday" in text and "result" in text)
+        or "finished game of wordle" in text
+        or "finished games of wordle" in text
+        or bool(parse_wordle_summary_text(content))
+    )
+
+
+def get_message_text(message: nextcord.Message) -> str:
+    parts = [message.content or ""]
+
+    for embed in message.embeds:
+        if embed.title:
+            parts.append(embed.title)
+        if embed.description:
+            parts.append(embed.description)
+        for field in embed.fields:
+            if field.name:
+                parts.append(field.name)
+            if field.value:
+                parts.append(field.value)
+        if embed.footer and embed.footer.text:
+            parts.append(embed.footer.text)
+
+    return "\n".join(parts)
 
 
 def format_wordle_leaderboard(rows):
@@ -54,13 +109,8 @@ def format_wordle_leaderboard(rows):
 
     lines = []
     for index, row in enumerate(rows, start=1):
-        user_id = row["user_id"]
-        total = row["total_score"]
-        games = row["games"]
-        hard_games = row["hard_games"]
-        failures = row["failures"]
         lines.append(
-            f"{index}. <@{user_id}> — {total} pts over {games} game(s), {hard_games} hard, {failures} failed"
+            f'{index}. <@{row["user_id"]}> — {row["total_score"]} pts over {row["games"]} game(s), {row["hard_games"]} hard, {row["failures"]} failed'
         )
 
     return "\n".join(lines)
@@ -100,6 +150,7 @@ class Wordle(commands.Cog):
         async for message in inter.channel.history(limit=50):
             if await self.process_wordle_result_message(message):
                 processed += 1
+            processed += await self.process_wordle_summary_message(message)
 
         await inter.followup.send(
             f"Started Wordle season from `{start.isoformat()}` to `{end.isoformat()}`. Processed {processed} existing result(s).",
@@ -161,8 +212,58 @@ class Wordle(commands.Cog):
             message_id=message.id,
             season_start=season["start_date"],
             season_end=season["end_date"],
+            source="user_share",
         )
         return True
+
+    async def process_wordle_summary_message(self, message: nextcord.Message) -> int:
+        if message.guild is None or not message.author.bot:
+            return 0
+
+        if getattr(message.channel, "name", None) != "wordle":
+            return 0
+
+        text = get_message_text(message)
+        entries = parse_wordle_summary_text(text)
+
+        if not entries:
+            return 0
+
+        season = await self.bot.db.wordle.get_active_season(message.guild.id)
+        if not season:
+            return 0
+
+        created_date = message.created_at.astimezone(timezone.utc).date()
+        played_date = created_date - timedelta(days=1) if "yesterday" in text.lower() else created_date
+        played_date_text = played_date.isoformat()
+
+        if played_date_text < season["start_date"] or played_date_text > season["end_date"]:
+            return 0
+
+        count = 0
+        for entry in entries:
+            member = message.guild.get_member(entry["user_id"])
+            username = member.display_name if member else str(entry["user_id"])
+
+            await self.bot.db.wordle.save_result(
+                guild_id=message.guild.id,
+                channel_id=message.channel.id,
+                user_id=entry["user_id"],
+                username=username,
+                puzzle=None,
+                tries=entry["tries"],
+                failed=entry["failed"],
+                hard_mode=entry["hard_mode"],
+                score=entry["score"],
+                played_date=played_date_text,
+                message_id=message.id,
+                season_start=season["start_date"],
+                season_end=season["end_date"],
+                source="wordle_bot_summary",
+            )
+            count += 1
+
+        return count
 
     async def post_leaderboard(self, message: nextcord.Message) -> None:
         season = await self.bot.db.wordle.get_active_season(message.guild.id)
@@ -171,6 +272,11 @@ class Wordle(commands.Cog):
 
         if season.get("last_summary_message_id") == message.id:
             return
+
+        await self.process_wordle_summary_message(message)
+
+        async for recent_message in message.channel.history(limit=100):
+            await self.process_wordle_result_message(recent_message)
 
         rows = await self.bot.db.wordle.get_leaderboard(
             message.guild.id,
@@ -192,7 +298,8 @@ class Wordle(commands.Cog):
         await self.process_wordle_result_message(message)
 
         if message.guild and message.author.bot and getattr(message.channel, "name", None) == "wordle":
-            if is_wordle_summary_message(message.content):
+            if is_wordle_summary_message(get_message_text(message)):
+                await asyncio.sleep(5)
                 await self.post_leaderboard(message)
 
 

--- a/src/database_handler.py
+++ b/src/database_handler.py
@@ -736,6 +736,103 @@ class TagsDatabase(BaseDatabase):
     async def remove_user_tags(self, user_id: int) -> None:
         await self.tags.delete_many({"user_id": user_id})
     
+
+class WordleDatabase(BaseDatabase):
+    def __init__(self, conf=None):
+        super().__init__(conf)
+        self.wordle_seasons = self.database["wordle_seasons"]
+        self.wordle_results = self.database["wordle_results"]
+
+    async def start_season(self, guild_id: int, channel_id: int, start_date: str, end_date: str) -> None:
+        await self.wordle_seasons.update_many(
+            {"guild_id": guild_id, "active": True},
+            {"$set": {"active": False}},
+        )
+        await self.wordle_seasons.insert_one({
+            "guild_id": guild_id,
+            "channel_id": channel_id,
+            "start_date": start_date,
+            "end_date": end_date,
+            "active": True,
+        })
+
+    async def get_active_season(self, guild_id: int):
+        return await self.wordle_seasons.find_one({"guild_id": guild_id, "active": True})
+
+    async def set_last_summary_message(self, guild_id: int, message_id: int) -> None:
+        await self.wordle_seasons.update_one(
+            {"guild_id": guild_id, "active": True},
+            {"$set": {"last_summary_message_id": message_id}},
+        )
+
+    async def save_result(
+        self,
+        guild_id: int,
+        channel_id: int,
+        user_id: int,
+        username: str,
+        puzzle: int,
+        tries,
+        failed: bool,
+        hard_mode: bool,
+        score: int,
+        played_date: str,
+        message_id: int,
+        season_start: str,
+        season_end: str,
+    ) -> None:
+        await self.wordle_results.update_one(
+            {
+                "guild_id": guild_id,
+                "user_id": user_id,
+                "puzzle": puzzle,
+                "season_start": season_start,
+                "season_end": season_end,
+            },
+            {
+                "$set": {
+                    "channel_id": channel_id,
+                    "username": username,
+                    "tries": tries,
+                    "failed": failed,
+                    "hard_mode": hard_mode,
+                    "score": score,
+                    "played_date": played_date,
+                    "message_id": message_id,
+                    "season_start": season_start,
+                    "season_end": season_end,
+                }
+            },
+            upsert=True,
+        )
+
+    async def get_leaderboard(self, guild_id: int, start_date: str, end_date: str) -> list:
+        docs = await self.wordle_results.find({
+            "guild_id": guild_id,
+            "season_start": start_date,
+            "season_end": end_date,
+        }).to_list(length=None)
+
+        users = {}
+        for doc in docs:
+            user_id = doc["user_id"]
+            users.setdefault(user_id, {
+                "user_id": user_id,
+                "username": doc.get("username", str(user_id)),
+                "total_score": 0,
+                "games": 0,
+                "hard_games": 0,
+                "failures": 0,
+            })
+            users[user_id]["total_score"] += int(doc.get("score", 0))
+            users[user_id]["games"] += 1
+            users[user_id]["hard_games"] += 1 if doc.get("hard_mode") else 0
+            users[user_id]["failures"] += 1 if doc.get("failed") else 0
+
+        return sorted(users.values(), key=lambda row: (row["total_score"], -row["games"], row["username"].lower()))
+
+
+
 class RecurrentDatabase(BaseDatabase):
 
     def __init__(self, conf=None):
@@ -814,5 +911,6 @@ class Database:
         self.appeal: AppealDatabase = AppealDatabase()
         self.recurrent: RecurrentDatabase = RecurrentDatabase()
         self.tags: TagsDatabase = TagsDatabase() 
+        self.wordle: WordleDatabase = WordleDatabase()
         self.config_lock = asyncio.Lock()
         self.config_data = {} 

--- a/src/database_handler.py
+++ b/src/database_handler.py
@@ -737,6 +737,7 @@ class TagsDatabase(BaseDatabase):
         await self.tags.delete_many({"user_id": user_id})
     
 
+
 class WordleDatabase(BaseDatabase):
     def __init__(self, conf=None):
         super().__init__(conf)
@@ -771,7 +772,7 @@ class WordleDatabase(BaseDatabase):
         channel_id: int,
         user_id: int,
         username: str,
-        puzzle: int,
+        puzzle,
         tries,
         failed: bool,
         hard_mode: bool,
@@ -780,19 +781,27 @@ class WordleDatabase(BaseDatabase):
         message_id: int,
         season_start: str,
         season_end: str,
+        source: str,
     ) -> None:
+        query = {
+            "guild_id": guild_id,
+            "user_id": user_id,
+            "played_date": played_date,
+            "season_start": season_start,
+            "season_end": season_end,
+        }
+
+        existing = await self.wordle_results.find_one(query)
+        if existing and existing.get("source") == "user_share" and source == "wordle_bot_summary" and not hard_mode:
+            return
+
         await self.wordle_results.update_one(
-            {
-                "guild_id": guild_id,
-                "user_id": user_id,
-                "puzzle": puzzle,
-                "season_start": season_start,
-                "season_end": season_end,
-            },
+            query,
             {
                 "$set": {
                     "channel_id": channel_id,
                     "username": username,
+                    "puzzle": puzzle,
                     "tries": tries,
                     "failed": failed,
                     "hard_mode": hard_mode,
@@ -801,6 +810,7 @@ class WordleDatabase(BaseDatabase):
                     "message_id": message_id,
                     "season_start": season_start,
                     "season_end": season_end,
+                    "source": source,
                 }
             },
             upsert=True,
@@ -830,7 +840,6 @@ class WordleDatabase(BaseDatabase):
             users[user_id]["failures"] += 1 if doc.get("failed") else 0
 
         return sorted(users.values(), key=lambda row: (row["total_score"], -row["games"], row["username"].lower()))
-
 
 
 class RecurrentDatabase(BaseDatabase):

--- a/src/startup.py
+++ b/src/startup.py
@@ -8,6 +8,7 @@ DEFAULT_COGS = [
     "cogs.bonk",
     "cogs.recurrent",
     "cogs.tags",
+    "cogs.wordle",
     "cogs.study",
     "cogs.events",
     "cogs.modmail",

--- a/tests/test_database_handler.py
+++ b/tests/test_database_handler.py
@@ -3,8 +3,16 @@ import copy
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
-from database_handler import BaseDatabase
+from database_handler import BaseDatabase, WordleDatabase
 from models import Infraction
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = [copy.deepcopy(doc) for doc in docs]
+
+    async def to_list(self, length=None):
+        return copy.deepcopy(self.docs)
 
 
 class FakeCollection:
@@ -42,12 +50,51 @@ class FakeCollection:
 
         return SimpleNamespace(modified_count=0)
 
+    async def update_one(self, query, update, upsert=False):
+        for index, doc in enumerate(self.docs):
+            if self._matches(doc, query):
+                stored = copy.deepcopy(doc)
+                stored.update(copy.deepcopy(update.get("$set", {})))
+                self.docs[index] = stored
+                return SimpleNamespace(modified_count=1, upserted_id=None)
+
+        if upsert:
+            stored = copy.deepcopy(query)
+            stored.update(copy.deepcopy(update.get("$set", {})))
+            stored.setdefault("_id", len(self.docs) + 1)
+            self.docs.append(stored)
+            return SimpleNamespace(modified_count=0, upserted_id=stored["_id"])
+
+        return SimpleNamespace(modified_count=0, upserted_id=None)
+
+    async def update_many(self, query, update):
+        modified_count = 0
+
+        for index, doc in enumerate(self.docs):
+            if self._matches(doc, query):
+                stored = copy.deepcopy(doc)
+                stored.update(copy.deepcopy(update.get("$set", {})))
+                self.docs[index] = stored
+                modified_count += 1
+
+        return SimpleNamespace(modified_count=modified_count)
+
+    def find(self, query):
+        return FakeCursor([doc for doc in self.docs if self._matches(doc, query)])
+
 
 def make_base_db(user_docs=None):
     db = object.__new__(BaseDatabase)
     db.user_config = FakeCollection(user_docs)
     db.bot_config = FakeCollection()
     db.database = {"channel_config": FakeCollection()}
+    return db
+
+
+def make_wordle_db(season_docs=None, result_docs=None):
+    db = object.__new__(WordleDatabase)
+    db.wordle_seasons = FakeCollection(season_docs)
+    db.wordle_results = FakeCollection(result_docs)
     return db
 
 
@@ -164,3 +211,44 @@ def test_get_user_infractions_normalizes_old_mute_records():
     assert infractions[0].duration == 1800
     assert infractions[0].attachment_url == "https://example.com/old.png"
     assert infractions[0].actiontime == datetime(2024, 2, 3, 10, 15, 0, tzinfo=timezone.utc)
+
+
+def test_wordle_start_season_deactivates_existing_active_season():
+    db = make_wordle_db([
+        {"guild_id": 1, "channel_id": 10, "start_date": "2026-05-01", "end_date": "2026-05-31", "active": True},
+    ])
+
+    asyncio.run(db.start_season(1, 20, "2026-06-01", "2026-06-30"))
+
+    assert db.wordle_seasons.docs[0]["active"] is False
+    assert db.wordle_seasons.docs[1]["active"] is True
+    assert db.wordle_seasons.docs[1]["channel_id"] == 20
+
+
+def test_wordle_leaderboard_sums_scores_and_sorts_lowest_first():
+    db = make_wordle_db()
+
+    asyncio.run(db.save_result(1, 10, 111, "Push", 1801, 4, False, False, 4, "2026-05-01", 100, "2026-05-01", "2026-05-31", "user_share"))
+    asyncio.run(db.save_result(1, 10, 111, "Push", 1802, 3, False, True, 2, "2026-05-02", 101, "2026-05-01", "2026-05-31", "user_share"))
+    asyncio.run(db.save_result(1, 10, 222, "Other", 1801, None, True, False, 7, "2026-05-01", 102, "2026-05-01", "2026-05-31", "user_share"))
+
+    rows = asyncio.run(db.get_leaderboard(1, "2026-05-01", "2026-05-31"))
+
+    assert rows[0]["user_id"] == 111
+    assert rows[0]["total_score"] == 6
+    assert rows[0]["games"] == 2
+    assert rows[0]["hard_games"] == 1
+    assert rows[1]["user_id"] == 222
+    assert rows[1]["failures"] == 1
+
+
+def test_wordle_summary_does_not_downgrade_hard_user_share():
+    db = make_wordle_db()
+
+    asyncio.run(db.save_result(1, 10, 111, "Push", 1801, 3, False, True, 2, "2026-05-01", 100, "2026-05-01", "2026-05-31", "user_share"))
+    asyncio.run(db.save_result(1, 10, 111, "Push", None, 3, False, False, 3, "2026-05-01", 101, "2026-05-01", "2026-05-31", "wordle_bot_summary"))
+
+    rows = asyncio.run(db.get_leaderboard(1, "2026-05-01", "2026-05-31"))
+
+    assert rows[0]["total_score"] == 2
+    assert rows[0]["hard_games"] == 1

--- a/tests/test_wordle_helpers.py
+++ b/tests/test_wordle_helpers.py
@@ -1,0 +1,59 @@
+from cogs.wordle import format_wordle_leaderboard, is_wordle_summary_message, parse_date, parse_wordle_result
+
+
+def test_parse_wordle_result_normal():
+    result = parse_wordle_result("Wordle 1801 4/6")
+
+    assert result["puzzle"] == 1801
+    assert result["tries"] == 4
+    assert result["failed"] is False
+    assert result["hard_mode"] is False
+    assert result["score"] == 4
+
+
+def test_parse_wordle_result_hard_mode_with_comma():
+    result = parse_wordle_result("Wordle 1,800 3/6*")
+
+    assert result["puzzle"] == 1800
+    assert result["tries"] == 3
+    assert result["failed"] is False
+    assert result["hard_mode"] is True
+    assert result["score"] == 2
+
+
+def test_parse_wordle_result_failed():
+    result = parse_wordle_result("Wordle 1801 X/6")
+
+    assert result["puzzle"] == 1801
+    assert result["tries"] is None
+    assert result["failed"] is True
+    assert result["hard_mode"] is False
+    assert result["score"] == 7
+
+
+def test_parse_wordle_result_invalid():
+    assert parse_wordle_result("push was playing") is None
+
+
+def test_is_wordle_summary_message():
+    assert is_wordle_summary_message("Your group is on a 7 day streak. Here are yesterday's results") is True
+    assert is_wordle_summary_message("push was playing") is False
+
+
+def test_parse_date():
+    assert parse_date("2026-05-25").isoformat() == "2026-05-25"
+    assert parse_date("05/25/2026") is None
+
+
+def test_format_wordle_leaderboard():
+    rows = [
+        {"user_id": 1, "total_score": 6, "games": 2, "hard_games": 1, "failures": 0},
+        {"user_id": 2, "total_score": 7, "games": 1, "hard_games": 0, "failures": 1},
+    ]
+
+    text = format_wordle_leaderboard(rows)
+
+    assert "<@1>" in text
+    assert "6 pts" in text
+    assert "<@2>" in text
+    assert "failed" in text

--- a/tests/test_wordle_helpers.py
+++ b/tests/test_wordle_helpers.py
@@ -1,4 +1,11 @@
-from cogs.wordle import format_wordle_leaderboard, is_wordle_summary_message, parse_date, parse_wordle_result
+from cogs.wordle import (
+    format_wordle_leaderboard,
+    is_wordle_summary_message,
+    parse_date,
+    parse_wordle_result,
+    parse_wordle_summary_text,
+    wordle_score,
+)
 
 
 def test_parse_wordle_result_normal():
@@ -35,9 +42,36 @@ def test_parse_wordle_result_invalid():
     assert parse_wordle_result("push was playing") is None
 
 
+def test_parse_wordle_summary_text():
+    text = "Here are yesterday's results:\\n3/6*: <@111>\\n4/6: <@222> <@!333>\\nX/6: <@444>"
+
+    results = parse_wordle_summary_text(text)
+
+    assert results[0]["user_id"] == 111
+    assert results[0]["tries"] == 3
+    assert results[0]["hard_mode"] is True
+    assert results[0]["score"] == 2
+    assert results[1]["user_id"] == 222
+    assert results[1]["tries"] == 4
+    assert results[1]["hard_mode"] is False
+    assert results[1]["score"] == 4
+    assert results[2]["user_id"] == 333
+    assert results[3]["user_id"] == 444
+    assert results[3]["failed"] is True
+    assert results[3]["score"] == 7
+
+
 def test_is_wordle_summary_message():
     assert is_wordle_summary_message("Your group is on a 7 day streak. Here are yesterday's results") is True
-    assert is_wordle_summary_message("push was playing") is False
+    assert is_wordle_summary_message("3/6: <@111>") is True
+    assert is_wordle_summary_message("push was playing\\n1 finished game of Wordle") is True
+    assert is_wordle_summary_message("hello") is False
+
+
+def test_wordle_score():
+    assert wordle_score(3, False, False) == 3
+    assert wordle_score(3, False, True) == 2
+    assert wordle_score(None, True, False) == 7
 
 
 def test_parse_date():

--- a/tests/test_wordle_helpers.py
+++ b/tests/test_wordle_helpers.py
@@ -1,4 +1,9 @@
+import asyncio
+from types import SimpleNamespace
+
 from cogs.wordle import (
+    Wordle,
+    date_in_season,
     format_wordle_leaderboard,
     is_wordle_summary_message,
     parse_date,
@@ -43,7 +48,7 @@ def test_parse_wordle_result_invalid():
 
 
 def test_parse_wordle_summary_text():
-    text = "Here are yesterday's results:\\n3/6*: <@111>\\n4/6: <@222> <@!333>\\nX/6: <@444>"
+    text = "Here are yesterday's results:\n3/6*: <@111>\n4/6 — <@222>, <@!333>\nX/6 <@444>"
 
     results = parse_wordle_summary_text(text)
 
@@ -64,7 +69,7 @@ def test_parse_wordle_summary_text():
 def test_is_wordle_summary_message():
     assert is_wordle_summary_message("Your group is on a 7 day streak. Here are yesterday's results") is True
     assert is_wordle_summary_message("3/6: <@111>") is True
-    assert is_wordle_summary_message("push was playing\\n1 finished game of Wordle") is True
+    assert is_wordle_summary_message("push was playing\n1 finished game of Wordle") is True
     assert is_wordle_summary_message("hello") is False
 
 
@@ -72,6 +77,14 @@ def test_wordle_score():
     assert wordle_score(3, False, False) == 3
     assert wordle_score(3, False, True) == 2
     assert wordle_score(None, True, False) == 7
+
+
+def test_date_in_season():
+    season = {"start_date": "2026-05-01", "end_date": "2026-05-31"}
+
+    assert date_in_season("2026-05-01", season) is True
+    assert date_in_season("2026-05-31", season) is True
+    assert date_in_season("2026-06-01", season) is False
 
 
 def test_parse_date():
@@ -91,3 +104,16 @@ def test_format_wordle_leaderboard():
     assert "6 pts" in text
     assert "<@2>" in text
     assert "failed" in text
+
+
+def test_resolve_username_fetches_member_when_not_cached():
+    class FakeGuild:
+        def get_member(self, user_id):
+            return None
+
+        async def fetch_member(self, user_id):
+            return SimpleNamespace(display_name="Fetched Name")
+
+    cog = Wordle(bot=object())
+
+    assert asyncio.run(cog.resolve_username(FakeGuild(), 123)) == "Fetched Name"


### PR DESCRIPTION
Added Task 2.

Changes:
- Extracts Wordle stats from shared result messages in #wordle
- Parses Wordle bot summary-style messages when they include scores and mentions
- Extracts username, user ID, tries, failed games, and hard mode
- Scores hard mode as attempt count minus one
- Scores normal mode as attempt count
- Scores X/6 as 7 points
- Adds /wordle start with start_date and end_date
- Adds /wordle leaderboard
- Stores seasonal scores
- Auto-posts the updated leaderboard when the Wordle bot posts a result/summary trigger
- Adds tests for result parsing, summary parsing, scoring, dates, and formatting