### PR TITLE
Fix Wordle leaderboard source handling

### DIFF
--- a/src/cogs/wordle.py
+++ b/src/cogs/wordle.py
@@ -13,6 +13,7 @@ conf = load_optional_config()
 COMMAND_GUILD_IDS = get_command_guild_ids(conf)
 
 WORDLE_RESULT_RE = re.compile(r"\bWordle\s+(\d[\d,]*)\s+([1-6X])/6(\*)?", re.IGNORECASE)
+WORDLE_PUZZLE_RE = re.compile(r"\bWordle\s+(\d[\d,]*)\b", re.IGNORECASE)
 WORDLE_SUMMARY_RE = re.compile(r"\b([1-6X])/6(\*)?(?=\s|[:\-–—]|$)\s*(?::|[-–—])?\s*((?:<@!?\d+>[\s,;]*)+)", re.IGNORECASE)
 MENTION_RE = re.compile(r"<@!?(\d+)>")
 
@@ -53,6 +54,33 @@ def can_manage_wordle(member) -> bool:
 
 def is_wordle_channel(channel) -> bool:
     return (getattr(channel, "name", "") or "").lower() == "wordle"
+
+
+def configured_wordle_bot_id():
+    value = conf.get("wordle_bot_id")
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_wordle_bot_author(author) -> bool:
+    if not getattr(author, "bot", False):
+        return False
+
+    expected_id = configured_wordle_bot_id()
+    if expected_id is not None:
+        return getattr(author, "id", None) == expected_id
+
+    names = (
+        getattr(author, "name", ""),
+        getattr(author, "display_name", ""),
+        getattr(author, "global_name", ""),
+    )
+    return any("wordle" in (name or "").lower() for name in names)
 
 
 def get_history_bounds(start, end):
@@ -106,6 +134,14 @@ def parse_wordle_result(content: str):
         "hard_mode": hard_mode,
         "score": wordle_score(tries, failed, hard_mode),
     }
+
+
+def parse_wordle_puzzle(content: str):
+    match = WORDLE_PUZZLE_RE.search(content)
+    if not match:
+        return None
+
+    return int(match.group(1).replace(",", ""))
 
 
 def parse_wordle_summary_text(content: str):
@@ -234,8 +270,6 @@ class Wordle(commands.Cog):
         processed = 0
 
         async for message in channel.history(limit=None, after=after, before=before, oldest_first=True):
-            if await self.process_wordle_result_message(message):
-                processed += 1
             processed += await self.process_wordle_summary_message(message)
 
         return processed
@@ -286,50 +320,21 @@ class Wordle(commands.Cog):
         await inter.send(embed=embed)
 
     async def process_wordle_result_message(self, message: nextcord.Message) -> bool:
-        if message.guild is None or message.author.bot:
-            return False
-
-        if not is_wordle_channel(message.channel):
-            return False
-
-        result = parse_wordle_result(message.content)
-        if result is None:
-            return False
-
-        season = await self.bot.db.wordle.get_active_season(message.guild.id)
-        if not season:
-            return False
-
-        played_date = get_message_date(message).isoformat()
-        if not date_in_season(played_date, season):
-            return False
-
-        await self.bot.db.wordle.save_result(
-            guild_id=message.guild.id,
-            channel_id=message.channel.id,
-            user_id=message.author.id,
-            username=message.author.display_name,
-            puzzle=result["puzzle"],
-            tries=result["tries"],
-            failed=result["failed"],
-            hard_mode=result["hard_mode"],
-            score=result["score"],
-            played_date=played_date,
-            message_id=message.id,
-            season_start=season["start_date"],
-            season_end=season["end_date"],
-            source="user_share",
-        )
-        return True
+        # Only the Wordle bot's daily summary should update the leaderboard.
+        # Member share messages are easy to spoof and can use the wrong puzzle.
+        return False
 
     async def process_wordle_summary_message(self, message: nextcord.Message) -> int:
-        if message.guild is None or not message.author.bot:
+        if message.guild is None or not is_wordle_bot_author(message.author):
             return 0
 
         if not is_wordle_channel(message.channel):
             return 0
 
         text = get_message_text(message)
+        if not is_wordle_summary_message(text):
+            return 0
+
         entries = parse_wordle_summary_text(text)
 
         if not entries:
@@ -345,6 +350,7 @@ class Wordle(commands.Cog):
             return 0
 
         count = 0
+        puzzle = parse_wordle_puzzle(text)
         for entry in entries:
             username = await self.resolve_username(message.guild, entry["user_id"])
 
@@ -353,7 +359,7 @@ class Wordle(commands.Cog):
                 channel_id=message.channel.id,
                 user_id=entry["user_id"],
                 username=username,
-                puzzle=None,
+                puzzle=puzzle,
                 tries=entry["tries"],
                 failed=entry["failed"],
                 hard_mode=entry["hard_mode"],
@@ -382,11 +388,6 @@ class Wordle(commands.Cog):
             return
 
         processed = await self.process_wordle_summary_message(message)
-        async for recent_message in message.channel.history(limit=100):
-            if get_message_date(recent_message).isoformat() != played_date:
-                continue
-            if await self.process_wordle_result_message(recent_message):
-                processed += 1
 
         if processed == 0:
             return
@@ -408,9 +409,7 @@ class Wordle(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message: nextcord.Message) -> None:
-        await self.process_wordle_result_message(message)
-
-        if message.guild and message.author.bot and is_wordle_channel(message.channel):
+        if message.guild and is_wordle_bot_author(message.author) and is_wordle_channel(message.channel):
             if is_wordle_summary_message(get_message_text(message)):
                 await asyncio.sleep(5)
                 await self.post_leaderboard(message)

--- a/src/database_handler.py
+++ b/src/database_handler.py
@@ -783,16 +783,25 @@ class WordleDatabase(BaseDatabase):
         season_end: str,
         source: str,
     ) -> None:
-        query = {
+        base_query = {
             "guild_id": guild_id,
             "user_id": user_id,
-            "played_date": played_date,
             "season_start": season_start,
             "season_end": season_end,
         }
+        query = dict(base_query)
+        if puzzle is not None:
+            query["puzzle"] = puzzle
+        else:
+            query["played_date"] = played_date
 
         existing = await self.wordle_results.find_one(query)
-        if existing and existing.get("source") == "user_share" and source == "wordle_bot_summary" and not hard_mode:
+        if not existing and puzzle is not None:
+            query = dict(base_query)
+            query["played_date"] = played_date
+            existing = await self.wordle_results.find_one(query)
+
+        if existing and existing.get("source") == "wordle_bot_summary" and source != "wordle_bot_summary":
             return
 
         await self.wordle_results.update_one(

--- a/tests/test_database_handler.py
+++ b/tests/test_database_handler.py
@@ -242,13 +242,14 @@ def test_wordle_leaderboard_sums_scores_and_sorts_lowest_first():
     assert rows[1]["failures"] == 1
 
 
-def test_wordle_summary_does_not_downgrade_hard_user_share():
+def test_wordle_summary_replaces_user_share_for_same_puzzle():
     db = make_wordle_db()
 
     asyncio.run(db.save_result(1, 10, 111, "Push", 1801, 3, False, True, 2, "2026-05-01", 100, "2026-05-01", "2026-05-31", "user_share"))
-    asyncio.run(db.save_result(1, 10, 111, "Push", None, 3, False, False, 3, "2026-05-01", 101, "2026-05-01", "2026-05-31", "wordle_bot_summary"))
+    asyncio.run(db.save_result(1, 10, 111, "Push", 1801, 4, False, False, 4, "2026-05-01", 101, "2026-05-01", "2026-05-31", "wordle_bot_summary"))
 
     rows = asyncio.run(db.get_leaderboard(1, "2026-05-01", "2026-05-31"))
 
-    assert rows[0]["total_score"] == 2
-    assert rows[0]["hard_games"] == 1
+    assert rows[0]["total_score"] == 4
+    assert rows[0]["hard_games"] == 0
+    assert db.wordle_results.docs[0]["source"] == "wordle_bot_summary"

--- a/tests/test_wordle_helpers.py
+++ b/tests/test_wordle_helpers.py
@@ -1,12 +1,16 @@
 import asyncio
+from datetime import datetime, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 from cogs.wordle import (
     Wordle,
     date_in_season,
     format_wordle_leaderboard,
+    is_wordle_bot_author,
     is_wordle_summary_message,
     parse_date,
+    parse_wordle_puzzle,
     parse_wordle_result,
     parse_wordle_summary_text,
     wordle_score,
@@ -43,6 +47,11 @@ def test_parse_wordle_result_failed():
     assert result["score"] == 7
 
 
+def test_parse_wordle_puzzle():
+    assert parse_wordle_puzzle("Wordle 1,800\nHere are yesterday's results") == 1800
+    assert parse_wordle_puzzle("Here are yesterday's results") is None
+
+
 def test_parse_wordle_result_invalid():
     assert parse_wordle_result("push was playing") is None
 
@@ -71,6 +80,12 @@ def test_is_wordle_summary_message():
     assert is_wordle_summary_message("3/6: <@111>") is True
     assert is_wordle_summary_message("push was playing\n1 finished game of Wordle") is True
     assert is_wordle_summary_message("hello") is False
+
+
+def test_is_wordle_bot_author_uses_bot_name():
+    assert is_wordle_bot_author(SimpleNamespace(bot=True, name="Wordle")) is True
+    assert is_wordle_bot_author(SimpleNamespace(bot=True, name="APBot")) is False
+    assert is_wordle_bot_author(SimpleNamespace(bot=False, name="Wordle")) is False
 
 
 def test_wordle_score():
@@ -117,3 +132,82 @@ def test_resolve_username_fetches_member_when_not_cached():
     cog = Wordle(bot=object())
 
     assert asyncio.run(cog.resolve_username(FakeGuild(), 123)) == "Fetched Name"
+
+
+def test_process_wordle_result_message_ignores_member_share():
+    wordle_db = SimpleNamespace(
+        get_active_season=AsyncMock(return_value={"start_date": "2026-05-25", "end_date": "2026-05-25"}),
+        save_result=AsyncMock(),
+    )
+    bot = SimpleNamespace(db=SimpleNamespace(wordle=wordle_db))
+    cog = Wordle(bot=bot)
+    message = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(bot=False, id=111, display_name="Player"),
+        channel=SimpleNamespace(id=10, name="wordle"),
+        content="Wordle 1,800 3/6*",
+        created_at=datetime(2026, 5, 25, tzinfo=timezone.utc),
+        id=55,
+    )
+
+    processed = asyncio.run(cog.process_wordle_result_message(message))
+
+    assert processed is False
+    wordle_db.save_result.assert_not_awaited()
+
+
+def test_process_wordle_summary_requires_wordle_bot():
+    wordle_db = SimpleNamespace(
+        get_active_season=AsyncMock(return_value={"start_date": "2026-05-25", "end_date": "2026-05-25"}),
+        save_result=AsyncMock(),
+    )
+    bot = SimpleNamespace(db=SimpleNamespace(wordle=wordle_db))
+    cog = Wordle(bot=bot)
+    message = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(bot=True, name="APBot", display_name="APBot"),
+        channel=SimpleNamespace(id=10, name="wordle"),
+        content="Wordle 1,800\nHere are yesterday's results:\n3/6*: <@111>",
+        embeds=[],
+        created_at=datetime(2026, 5, 26, tzinfo=timezone.utc),
+        id=56,
+    )
+
+    processed = asyncio.run(cog.process_wordle_summary_message(message))
+
+    assert processed == 0
+    wordle_db.save_result.assert_not_awaited()
+
+
+def test_process_wordle_summary_records_puzzle_from_wordle_bot():
+    guild = SimpleNamespace(
+        id=1,
+        get_member=lambda user_id: SimpleNamespace(display_name="Player"),
+    )
+    wordle_db = SimpleNamespace(
+        get_active_season=AsyncMock(return_value={"start_date": "2026-05-25", "end_date": "2026-05-25"}),
+        save_result=AsyncMock(),
+    )
+    bot = SimpleNamespace(db=SimpleNamespace(wordle=wordle_db))
+    cog = Wordle(bot=bot)
+    message = SimpleNamespace(
+        guild=guild,
+        author=SimpleNamespace(bot=True, name="Wordle", display_name="Wordle"),
+        channel=SimpleNamespace(id=10, name="wordle"),
+        content="Wordle 1,800\nHere are yesterday's results:\n3/6*: <@111>",
+        embeds=[],
+        created_at=datetime(2026, 5, 26, tzinfo=timezone.utc),
+        id=57,
+    )
+
+    processed = asyncio.run(cog.process_wordle_summary_message(message))
+
+    assert processed == 1
+    kwargs = wordle_db.save_result.await_args.kwargs
+    assert kwargs["user_id"] == 111
+    assert kwargs["username"] == "Player"
+    assert kwargs["puzzle"] == 1800
+    assert kwargs["hard_mode"] is True
+    assert kwargs["score"] == 2
+    assert kwargs["played_date"] == "2026-05-25"
+    assert kwargs["source"] == "wordle_bot_summary"


### PR DESCRIPTION
Fixes the Wordle leaderboard so it only records results from the actual Wordle bot summary instead of regular member

Changes:
- Ignores normal user Wordle share messages.
- Only processes Wordle bot summary messages.
- Records the Wordle puzzle number when available.
- Lets official summary data replace older user-share data for the same puzzle.